### PR TITLE
Added url only option

### DIFF
--- a/src/metget/metget_build.py
+++ b/src/metget/metget_build.py
@@ -327,6 +327,7 @@ class MetGetBuildRest:
             sleep_time (int): Time to sleep between status checks
             max_wait (int): Maximum time to wait for data to appear
             output_directory (Union[str, None]): Output directory
+            return_only_url (bool): If true the url of the files and the filelist will be returned instead of them being saved (Default=False)
 
         Returns:
             None


### PR DESCRIPTION
When building custom application with the metget library, it is sometimes useful to avoid saving the netcdf files and filelist.json , but just return them as variables instead.

In this pull request an extra option is added in the client.download_metget_data() method to allow for this with the **return_only_url** argument (which defaults to False, for backward compatibility).

Additionally, the location of the filelist.json is now changed to be always the same as the dir of the output.