### PR TITLE
Add Google DeepMind cyclone ensemble support to client

### DIFF
--- a/src/metget/metget_build.py
+++ b/src/metget/metget_build.py
@@ -112,6 +112,33 @@ class MetGetBuildRest:
             ensemble_member = model.split("-")[2]
             storm = model.split("-")[1]
             model = "ctcx"
+        elif "deepmind" in model:
+            # DeepMind has no advisory numbers; forecasts are identified by their forecast
+            # cycle (YYYYMMDDHH, 00/06/12/18Z), and an ensemble member ("F000"-"F049" or
+            # "mean") is always required. The storm year is derived from the cycle.
+            keys = model.split("-")
+            if len(keys) != 5:
+                msg = (
+                    "Must include basin, storm number, forecast cycle, and ensemble "
+                    "member with DEEPMIND request as "
+                    "'deepmind-basin-storm-cycle-ensemble_member' where the cycle is "
+                    "a 10-digit YYYYMMDDHH string (e.g. "
+                    "'deepmind-al-02-2026072206-F007' or "
+                    "'deepmind-al-02-2026072206-mean')"
+                )
+                raise RuntimeError(msg)
+            basin = keys[1]
+            storm = keys[2]
+            advisory = keys[3]
+            ensemble_member = keys[4]
+            if len(advisory) != 10 or not advisory.isdigit():
+                msg = (
+                    f"DeepMind forecast cycle '{advisory}' is not a 10-digit "
+                    "'YYYYMMDDHH' string"
+                )
+                raise RuntimeError(msg)
+            year = int(advisory[0:4])
+            model = "deepmind"
         elif "nhc" in model or "jtwc" in model:
             source = model.split("-")[0]
             if len(model.split("-")) < 4:
@@ -214,6 +241,23 @@ class MetGetBuildRest:
                 "storm": storm,
                 "storm_year": year,
                 "advisory": advisory,
+                "x_init": xmin,
+                "y_init": ymin,
+                "x_end": xmax,
+                "y_end": ymax,
+                "di": res,
+                "dj": res,
+                "level": level,
+            }
+        elif model == "deepmind":
+            return {
+                "name": f"deepmind-{basin}{storm}-{ensemble_member}",
+                "service": AVAILABLE_MODELS[model],
+                "basin": basin,
+                "storm": storm,
+                "storm_year": year,
+                "advisory": advisory,
+                "ensemble_member": ensemble_member,
                 "x_init": xmin,
                 "y_init": ymin,
                 "x_end": xmax,

--- a/src/metget/metget_client.py
+++ b/src/metget/metget_client.py
@@ -132,6 +132,11 @@ def initialize_build_cli(subparsers):
         " where basin is a two letter string denoting the basin (nhc: al, ep, cp; jtwc: wp, io, sh),"
         " storm number is the id of the storm (not the name), and the advisory number"
         " is the advisory to use to build the merged data (or 0 for best-track data only)."
+        " For DEEPMIND (Google DeepMind cyclone ensemble) data specify as"
+        " 'deepmind-basin-storm_number-cycle-ensemble_member' where the cycle is the"
+        " 10-digit YYYYMMDDHH forecast cycle (00/06/12/18Z; DeepMind has no advisory"
+        " numbers) and the ensemble member is 'F000'-'F049' or 'mean' for the ensemble"
+        " mean (e.g. 'deepmind-al-02-2026072206-F007'); only '--format raw' is supported."
         " For grtofs (Global RTOFS ocean data), only '--format raw' is supported and the"
         " data is always global; the resolution and corner values are ignored"
         " (e.g. 'grtofs 0.08 -180 -90 180 90').",
@@ -293,7 +298,7 @@ def initialize_status_cli(subparsers):
     )
     status.add_argument(
         "--basin",
-        help="For NHC/JTWC based data, request a specific basin",
+        help="For NHC/JTWC/DeepMind based data, request a specific basin",
         type=str,
         metavar="s",
     )

--- a/src/metget/metget_data.py
+++ b/src/metget/metget_data.py
@@ -44,13 +44,15 @@ AVAILABLE_MODELS = {
     "ctcx": "coamps-ctcx",
     "nhc": "nhc",
     "jtwc": "jtwc",
+    "deepmind": "deepmind",
     "grtofs": "rtofs",
     "era5": "era5",
 }
 
 # Models which deliver raw data files only (no gridded interpolation). Global RTOFS
-# is raw ocean model NetCDF used for downstream baroclinic forcing generation
-RAW_ONLY_MODELS = {"grtofs"}
+# is raw ocean model NetCDF used for downstream baroclinic forcing generation;
+# DeepMind delivers raw ATCF ensemble track files
+RAW_ONLY_MODELS = {"grtofs", "deepmind"}
 
 # Client model names whose server-side status model name differs
 STATUS_MODEL_ALIASES = {"grtofs": "rtofs"}
@@ -73,6 +75,7 @@ MODEL_TYPES = {
     "era5": "hindcast",
     "nhc": "track",
     "jtwc": "track",
+    "deepmind": "track-ensemble",
     "grtofs": "synoptic",
 }
 

--- a/src/metget/metget_status.py
+++ b/src/metget/metget_status.py
@@ -80,6 +80,8 @@ class MetGetStatus:
         #     self.__status_hindcast(model)
         elif self.__model_class == "track":
             self.__status_track(model)
+        elif self.__model_class == "track-ensemble":
+            self.__status_track_ensemble(model)
         else:
             msg = "Unknown model type."
             raise RuntimeError(msg)
@@ -229,6 +231,90 @@ class MetGetStatus:
             table.reversesort = True
             print(table.get_string(sortby="Best Track End"))
 
+        else:
+            msg = "Unknown format"
+            raise RuntimeError(msg)
+
+    def __status_track_ensemble(self, model: str) -> None:
+        """
+        This method is used to get the status of ensemble track data (DeepMind). The
+        server response is nested year -> basin -> storm, each with the available
+        forecast cycles and ensemble members.
+
+        Args:
+            model: The model to get the status for
+        """
+        url = "{:s}/status?model={:s}".format(self.__environment["endpoint"], model)
+        url = self.__add_url_start_end_parameters(url)
+        if self.__args.ensemble_member:
+            url += f"&member={self.__args.ensemble_member:s}"
+
+        response = requests.get(
+            url, headers={"x-api-key": self.__environment["apikey"]}
+        )
+        data = response.json()["body"]
+
+        # ...The deepmind status endpoint does not take year/basin/storm query
+        # parameters, so those command line filters are applied client-side
+        if self.__args.year:
+            data = {k: v for k, v in data.items() if k == str(self.__args.year)}
+        if self.__args.basin:
+            data = {
+                year: {
+                    basin: storms
+                    for basin, storms in basins.items()
+                    if basin == self.__args.basin.lower()
+                }
+                for year, basins in data.items()
+            }
+        if self.__args.storm:
+            data = {
+                year: {
+                    basin: {
+                        storm: info
+                        for storm, info in storms.items()
+                        if storm == self.__args.storm
+                    }
+                    for basin, storms in basins.items()
+                }
+                for year, basins in data.items()
+            }
+
+        if self.__args.format == "json":
+            print(json.dumps(data))
+        elif self.__args.format == "pretty":
+            table = prettytable.PrettyTable(
+                [
+                    "Year",
+                    "Basin",
+                    "Storm",
+                    "First Cycle",
+                    "Latest Cycle",
+                    "Cycle Count",
+                    "Members",
+                ]
+            )
+            for year in data:
+                for basin in data[year]:
+                    for storm, info in data[year][basin].items():
+                        members = info["members"]
+                        if len(members) > 6:
+                            members = [*members[:3], "...", *members[-3:]]
+                        elif len(members) == 0:
+                            members = ["None"]
+                        table.add_row(
+                            [
+                                year,
+                                basin,
+                                storm,
+                                info["first_cycle"],
+                                info["latest_cycle"],
+                                info["cycle_count"],
+                                " ".join(members),
+                            ]
+                        )
+            table.reversesort = True
+            print(table.get_string(sortby="Latest Cycle"))
         else:
             msg = "Unknown format"
             raise RuntimeError(msg)

--- a/test/build_json.py
+++ b/test/build_json.py
@@ -325,3 +325,40 @@ METGET_BUILD_JTWC_JSON = {
     "strict": False,
     "dry_run": False,
 }
+
+METGET_BUILD_DEEPMIND_JSON = {
+    "version": "0.0.1",
+    "creator": "pytest",
+    "background_pressure": 1013.0,
+    "backfill": False,
+    "nowcast": False,
+    "multiple_forecasts": True,
+    "start_date": "2026-07-22 06:00:00",
+    "end_date": "2026-07-23 06:00:00",
+    "format": "raw",
+    "data_type": "wind_pressure",
+    "time_step": 3600,
+    "domains": [
+        {
+            "name": "deepmind-al02-F007",
+            "service": "deepmind",
+            "basin": "al",
+            "storm": "02",
+            "storm_year": 2026,
+            "advisory": "2026072206",
+            "ensemble_member": "F007",
+            "x_init": -90.0,
+            "y_init": 15.0,
+            "x_end": -80.0,
+            "y_end": 25.0,
+            "di": 0.1,
+            "dj": 0.1,
+            "level": 0,
+        }
+    ],
+    "compression": False,
+    "epsg": 4326,
+    "filename": "test_build_deepmind",
+    "strict": False,
+    "dry_run": False,
+}

--- a/test/status_json.py
+++ b/test/status_json.py
@@ -4197,3 +4197,52 @@ JTWC_STATUS_JSON = {
         },
     },
 }
+
+DEEPMIND_STATUS_JSON = {
+    "statusCode": 200,
+    "body": {
+        "2026": {
+            "al": {
+                "02": {
+                    "first_cycle": "2026-07-22 00:00:00",
+                    "latest_cycle": "2026-07-22 06:00:00",
+                    "cycle_count": 2,
+                    "cycles": [
+                        "2026-07-22 00:00:00",
+                        "2026-07-22 06:00:00",
+                    ],
+                    "members": ["F000", "F001", "F007", "mean"],
+                }
+            },
+            "ep": {
+                "06": {
+                    "first_cycle": "2026-07-22 06:00:00",
+                    "latest_cycle": "2026-07-22 06:00:00",
+                    "cycle_count": 1,
+                    "cycles": ["2026-07-22 06:00:00"],
+                    "members": ["F000", "F001", "F007", "mean"],
+                }
+            },
+        }
+    },
+}
+
+DEEPMIND_STATUS_JSON_MEAN = {
+    "statusCode": 200,
+    "body": {
+        "2026": {
+            "al": {
+                "02": {
+                    "first_cycle": "2026-07-22 00:00:00",
+                    "latest_cycle": "2026-07-22 06:00:00",
+                    "cycle_count": 2,
+                    "cycles": [
+                        "2026-07-22 00:00:00",
+                        "2026-07-22 06:00:00",
+                    ],
+                    "members": ["mean"],
+                }
+            }
+        }
+    },
+}

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -12,6 +12,7 @@ from metget.metget_environment import get_metget_environment_variables
 from .build_json import (
     METGET_BUILD_COAMPS_JSON,
     METGET_BUILD_CTCX_JSON,
+    METGET_BUILD_DEEPMIND_JSON,
     METGET_BUILD_GEFS_JSON,
     METGET_BUILD_GFS_JSON,
     METGET_BUILD_HWRF_JSON,
@@ -1303,3 +1304,99 @@ def test_build_output_directory_validation() -> None:
             client.download_metget_data(
                 data_id, args.check_interval, args.max_wait, args.output_directory
             )
+
+
+def test_build_deepmind_raw(capfd) -> None:
+    """
+    **TEST PURPOSE**: Validates Google DeepMind ensemble raw data build request
+    **MODULE**: metget_build.MetGetBuildRest
+    **SCENARIO**: Build raw format DeepMind data for one storm/cycle/ensemble member
+    **INPUT**: deepmind model, storm 02 in AL basin, cycle 2026072206, member F007, raw format
+    **EXPECTED**: Generates deepmind request JSON with cycle carried in the advisory field,
+                  storm_year derived from the cycle, and the ensemble member included
+    **COVERAGE**: Tests deepmind domain string parsing and raw format request generation
+    """
+    args = argparse.Namespace()
+    args.analysis = False
+    args.multiple_forecasts = True
+    args.variable = "wind_pressure"
+    args.backfill = False
+    args.domain = [["deepmind-al-02-2026072206-F007", 0.1, -90, 15, -80, 25]]
+    args.start = datetime(2026, 7, 22, 6)
+    args.end = datetime(2026, 7, 23, 6)
+    args.initialization_skip = 0
+    args.timestep = 3600
+    args.format = "raw"
+    args.output = "test_build_deepmind"
+    args.dryrun = False
+    args.strict = False
+    args.epsg = 4326
+    args.compression = False
+
+    args.endpoint = METGET_DMY_ENDPOINT
+    args.apikey = METGET_DMY_APIKEY
+    args.api_version = METGET_API_VERSION
+
+    request_dict = MetGetBuildRest.generate_request_json(
+        analysis=args.analysis,
+        multiple_forecasts=args.multiple_forecasts,
+        start_date=args.start,
+        end_date=args.end,
+        format=args.format,
+        timestep=args.timestep,
+        data_type=args.variable,
+        backfill=args.backfill,
+        filename=args.output,
+        dry_run=args.dryrun,
+        strict=args.strict,
+        domains=MetGetBuildRest.parse_command_line_domains(
+            args.domain, args.initialization_skip
+        ),
+    )
+    request_dict["creator"] = "pytest"
+
+    assert request_dict == METGET_BUILD_DEEPMIND_JSON
+
+    environment = get_metget_environment_variables(args)
+    client = MetGetBuildRest(
+        environment["endpoint"], environment["apikey"], environment["api_version"]
+    )
+
+    with requests_mock.Mocker() as m:
+        m.post(METGET_DMY_ENDPOINT + "/build", json=METGET_BUILD_POST_RETURN)
+        data_id, status_code = client.make_metget_request(request_dict)
+
+    assert data_id == "5f9b5b3c-5b7a-4c5e-8b0a-1b5b3c5d7e8f"
+    assert status_code == 200
+
+
+def test_build_deepmind_mean_domain() -> None:
+    """
+    **TEST PURPOSE**: Validates the deepmind ensemble-mean domain string
+    **MODULE**: metget_build.MetGetBuildRest.parse_domain_data
+    **SCENARIO**: The 'mean' ensemble member selects the ensemble-mean product
+    **EXPECTED**: Domain dict carries ensemble_member 'mean'
+    """
+    domain = MetGetBuildRest.parse_domain_data(
+        ["deepmind-al-02-2026072206-mean", 0.1, -90, 15, -80, 25], 0, 0
+    )
+    assert domain["service"] == "deepmind"
+    assert domain["ensemble_member"] == "mean"
+    assert domain["advisory"] == "2026072206"
+    assert domain["storm_year"] == 2026
+
+
+def test_build_deepmind_domain_errors() -> None:
+    """
+    **TEST PURPOSE**: Validates error handling for malformed deepmind domain strings
+    **MODULE**: metget_build.MetGetBuildRest.parse_domain_data
+    **SCENARIO**: Missing ensemble member or malformed cycle must raise with a clear message
+    """
+    with pytest.raises(RuntimeError, match="ensemble"):
+        MetGetBuildRest.parse_domain_data(
+            ["deepmind-al-02-2026072206", 0.1, -90, 15, -80, 25], 0, 0
+        )
+    with pytest.raises(RuntimeError, match="YYYYMMDDHH"):
+        MetGetBuildRest.parse_domain_data(
+            ["deepmind-al-02-garbage-F007", 0.1, -90, 15, -80, 25], 0, 0
+        )

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -9,6 +9,8 @@ from metget.metget_status import MetGetStatus
 
 from .status_json import (
     COAMPS_CTCX_STATUS_JSON,
+    DEEPMIND_STATUS_JSON,
+    DEEPMIND_STATUS_JSON_MEAN,
     GEFS_STATUS_JSON,
     GEFS_STATUS_JSON_C00,
     GFS_STATUS_JSON,
@@ -430,3 +432,99 @@ def test_get_status_hafs(capfd) -> None:
         out, err = capfd.readouterr()
         out_dict = json.loads(out)
         assert out_dict == HAFS_STATUS_JSON["body"]
+
+
+def test_status_deepmind(capfd) -> None:
+    """
+    Tests the status command for the Google DeepMind ensemble track model
+    Args:
+        capfd: pytest fixture to capture stdout and stderr
+
+    Returns:
+        None
+    """
+    args = argparse.Namespace()
+    args.model = "deepmind"
+    args.start = datetime(2026, 7, 22)
+    args.end = datetime(2026, 7, 23)
+    args.ensemble_member = None
+    args.format = "json"
+    args.storm = None
+    args.basin = None
+    args.year = None
+    args.complete = False
+    args.endpoint = METGET_DMY_ENDPOINT
+    args.apikey = METGET_DMY_APIKEY
+    args.api_version = METGET_API_VERSION
+
+    url = (
+        METGET_DMY_ENDPOINT
+        + "/status?"
+        + urlencode(
+            {
+                "model": "deepmind",
+                "start": "2026-07-22",
+                "end": "2026-07-23",
+            }
+        )
+    )
+
+    with requests_mock.Mocker() as m:
+        m.get(url, json=DEEPMIND_STATUS_JSON)
+        s = MetGetStatus(args)
+        s.get_status()
+        out, err = capfd.readouterr()
+        assert json.loads(out) == DEEPMIND_STATUS_JSON["body"]
+
+    args.format = "pretty"
+    with requests_mock.Mocker() as m:
+        m.get(url, json=DEEPMIND_STATUS_JSON)
+        s = MetGetStatus(args)
+        s.get_status()
+        out, err = capfd.readouterr()
+        assert "deepmind-al02" not in out  # sanity: table output, not raw json
+        assert "F000 F001 F007 mean" in out
+        assert "2026-07-22 06:00:00" in out
+        assert out.count("| 2026 |") == 2
+
+
+def test_status_deepmind_member_filter(capfd) -> None:
+    """
+    Tests the status command for deepmind with a specific ensemble member
+    and client-side basin filtering
+    """
+    args = argparse.Namespace()
+    args.model = "deepmind"
+    args.start = datetime(2026, 7, 22)
+    args.end = datetime(2026, 7, 23)
+    args.ensemble_member = "mean"
+    args.format = "json"
+    args.storm = None
+    args.basin = "al"
+    args.year = None
+    args.complete = False
+    args.endpoint = METGET_DMY_ENDPOINT
+    args.apikey = METGET_DMY_APIKEY
+    args.api_version = METGET_API_VERSION
+
+    url = (
+        METGET_DMY_ENDPOINT
+        + "/status?"
+        + urlencode(
+            {
+                "model": "deepmind",
+                "start": "2026-07-22",
+                "end": "2026-07-23",
+                "member": "mean",
+            }
+        )
+    )
+
+    with requests_mock.Mocker() as m:
+        m.get(url, json=DEEPMIND_STATUS_JSON_MEAN)
+        s = MetGetStatus(args)
+        s.get_status()
+        out, err = capfd.readouterr()
+        data = json.loads(out)
+        assert data == DEEPMIND_STATUS_JSON_MEAN["body"]
+        assert data["2026"]["al"]["02"]["members"] == ["mean"]


### PR DESCRIPTION
Adding Google DeepMind tracks to MetGet. DeepMind provides a 50-member ATCF ensemble + an ensemble mean member